### PR TITLE
Add support for Vue components

### DIFF
--- a/themes/Rainier-Retro-color-theme.json
+++ b/themes/Rainier-Retro-color-theme.json
@@ -414,6 +414,13 @@
       }
     },
     {
+      "name": "Vue Component",
+      "scope": ["support.class.component.html"],
+      "settings": {
+        "foreground": "#008b94"
+      }
+    },
+    {
       "name": "Support Variable Property DOM",
       "scope": "support.variable.property.dom",
       "settings": {

--- a/themes/Rainier-Shadow-color-theme.json
+++ b/themes/Rainier-Shadow-color-theme.json
@@ -422,6 +422,13 @@
       }
     },
     {
+      "name": "Vue Component",
+      "scope": ["support.class.component.html"],
+      "settings": {
+        "foreground": "#008b94"
+      }
+    },
+    {
       "name": "Support Variable Property DOM",
       "scope": "support.variable.property.dom",
       "settings": {

--- a/themes/Rainier-color-theme.json
+++ b/themes/Rainier-color-theme.json
@@ -422,6 +422,13 @@
       }
     },
     {
+      "name": "Vue Component",
+      "scope": ["support.class.component.html"],
+      "settings": {
+        "foreground": "#008b94"
+      }
+    },
+    {
       "name": "Support Variable Property DOM",
       "scope": "support.variable.property.dom",
       "settings": {


### PR DESCRIPTION
I noticed that a recent change in [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) broke Rainier's highlighting of PascalCase Vue components:

<img width="1065" alt="Screen Shot 2020-09-09 at 12 08 33 AM" src="https://user-images.githubusercontent.com/801425/92557323-911ae680-f231-11ea-906e-4b00b9b19cd1.png">

I added a rule to style them:

<img width="1059" alt="Screen Shot 2020-09-09 at 12 13 11 AM" src="https://user-images.githubusercontent.com/801425/92557405-c6bfcf80-f231-11ea-80f6-35b731c5ef6a.png">

I opted for making it the same as the JSX React Class rule (#008b94) for consistency but I also think #37c2b6 works as well, and it’s my personal preference.