### PR TITLE
Highlighting improvements for PHP and JavaScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.vsix
+*.vscode

--- a/themes/Rainier-Retro-color-theme.json
+++ b/themes/Rainier-Retro-color-theme.json
@@ -10,6 +10,7 @@
     "entity.other": "#509ddb",
     "function.declaration": "#37c2b6",
     "function": "#509ddb",
+    "method": "#509ddb",
     "method.declaration": "#37c2b6",
     "parameter": "#d6af78",
     "selfParameter": "#c693da",
@@ -233,10 +234,21 @@
       }
     },
     {
+      "name": "Class",
+      "scope": [
+        "entity.name.type.class",
+        "support.class"
+      ],
+      "settings": {
+        "foreground": "#37c2b6"
+      }
+    },
+    {
       "name": "Function",
       "scope": [
         "meta.function-call.generic",
-        "support.type.python"
+        "support.type.python",
+        "entity.name.function"
       ],
       "settings": {
         "foreground": "#509ddb"
@@ -293,6 +305,7 @@
         "meta.at-rule.function variable",
         "meta.at-rule.mixin variable",
         "meta.function.arguments",
+        "meta.function.parameter variable.other",
         "meta.selectionset.graphql meta.arguments.graphql variable.arguments.graphql",
         "variable.parameter"
       ],
@@ -609,15 +622,6 @@
       "scope": [
         "punctuation.definition.string.end.json",
         "punctuation.definition.string.begin.json"
-      ],
-      "settings": {
-        "foreground": "#509ddb"
-      }
-    },
-    {
-      "name": "[PHP]",
-      "scope": [
-        "entity.name.function.php",
       ],
       "settings": {
         "foreground": "#509ddb"

--- a/themes/Rainier-Shadow-color-theme.json
+++ b/themes/Rainier-Shadow-color-theme.json
@@ -10,6 +10,7 @@
     "entity.other": "#509ddb",
     "function.declaration": "#37c2b6",
     "function": "#509ddb",
+    "method": "#509ddb",
     "method.declaration": "#37c2b6",
     "parameter": "#d6af78",
     "selfParameter": "#c693da",
@@ -239,10 +240,21 @@
       }
     },
     {
+      "name": "Class",
+      "scope": [
+        "entity.name.type.class",
+        "support.class"
+      ],
+      "settings": {
+        "foreground": "#37c2b6"
+      }
+    },
+    {
       "name": "Function",
       "scope": [
         "meta.function-call.generic",
-        "support.type.python"
+        "support.type.python",
+        "entity.name.function"
       ],
       "settings": {
         "foreground": "#509ddb"
@@ -299,6 +311,7 @@
         "meta.at-rule.function variable",
         "meta.at-rule.mixin variable",
         "meta.function.arguments",
+        "meta.function.parameter variable.other",
         "meta.selectionset.graphql meta.arguments.graphql variable.arguments.graphql",
         "variable.parameter"
       ],
@@ -615,15 +628,6 @@
       "scope": [
         "punctuation.definition.string.end.json",
         "punctuation.definition.string.begin.json"
-      ],
-      "settings": {
-        "foreground": "#509ddb"
-      }
-    },
-    {
-      "name": "[PHP]",
-      "scope": [
-        "entity.name.function.php",
       ],
       "settings": {
         "foreground": "#509ddb"

--- a/themes/Rainier-color-theme.json
+++ b/themes/Rainier-color-theme.json
@@ -10,6 +10,7 @@
     "entity.other": "#509ddb",
     "function.declaration": "#37c2b6",
     "function": "#509ddb",
+    "method": "#509ddb",
     "method.declaration": "#37c2b6",
     "parameter": "#d6af78",
     "selfParameter": "#c693da",
@@ -239,10 +240,21 @@
       }
     },
     {
+      "name": "Class",
+      "scope": [
+        "entity.name.type.class",
+        "support.class"
+      ],
+      "settings": {
+        "foreground": "#37c2b6"
+      }
+    },
+    {
       "name": "Function",
       "scope": [
         "meta.function-call.generic",
-        "support.type.python"
+        "support.type.python",
+        "entity.name.function",
       ],
       "settings": {
         "foreground": "#509ddb"
@@ -299,6 +311,7 @@
         "meta.at-rule.function variable",
         "meta.at-rule.mixin variable",
         "meta.function.arguments",
+        "meta.function.parameter variable.other",
         "meta.selectionset.graphql meta.arguments.graphql variable.arguments.graphql",
         "variable.parameter"
       ],
@@ -615,15 +628,6 @@
       "scope": [
         "punctuation.definition.string.end.json",
         "punctuation.definition.string.begin.json"
-      ],
-      "settings": {
-        "foreground": "#509ddb"
-      }
-    },
-    {
-      "name": "[PHP]",
-      "scope": [
-        "entity.name.function.php",
       ],
       "settings": {
         "foreground": "#509ddb"


### PR DESCRIPTION
@joytrekker Thanks for the update! Looks good. I noticed that PHP was missing highlighting for classes and parameters so I added some scopes to fix that. I also added some scopes to make JavaScript function calls blue. I tried to make small adjustments so as not to over highlight.

Here's an example:

<img width="747" alt="Screen Shot 2021-04-18 at 10 33 30 PM" src="https://user-images.githubusercontent.com/801425/115178300-988f5180-a096-11eb-9472-498140d0803b.png">
